### PR TITLE
feat: add documentation/making-of skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,12 @@ This repository serves as a shared reference for AI agents and human developers.
 
 ## Available skills
 
+### Documentation
+
+| Skill | Description |
+|-------|-------------|
+| [`making-of`](skills/documentation/making-of/README.md) | Maintain a first-person making-of journal recording how a project is built — decisions, dead ends, and reversals — updated at the end of each AI-assisted session |
+
 ### GitHub Actions
 
 | Skill | Description |

--- a/skills/documentation/making-of/README.md
+++ b/skills/documentation/making-of/README.md
@@ -1,0 +1,60 @@
+# making-of
+
+Maintain a first-person "making-of" journal in a repository — a blog-ish account of how the project is being built, updated at the end of each AI-assisted work session.
+
+## Purpose
+
+Formal docs explain **what** the project is. A making-of records **how it came together**: the reasoning, the measurements, the false starts, and the reversals — especially the reversals. It is written for new contributors, for future-you, and for anyone curious about building software with AI agents, and it may later turn into an actual blog post.
+
+## What it does
+
+1. Creates a `MAKING-OF.md` at the repository root (or adds a new entry to an existing one).
+2. Writes in the **author's first-person voice** — the human's journal, drafted by the agent.
+3. At the end of a work session, appends a new section covering what happened since the last update: decisions, dead ends, links to PRs/issues, measured numbers.
+4. Updates the **Last updated** date on every edit.
+5. When the file grows too large, splits into one post per milestone under `doc/making-of/`, with the root file becoming an index.
+
+## The two layouts
+
+| Layout | When to use | Structure |
+|--------|-------------|-----------|
+| **Single living document** | One continuous investigation or a small/medium project | One `MAKING-OF.md`, sections added over time |
+| **Post series** | A project shipped milestone by milestone | Root `MAKING-OF.md` is an index; each milestone gets `doc/making-of/NN-slug.md` |
+
+Start with the single document. Split only when a section boundary is natural (a milestone shipped) **and** the file no longer reads in one sitting.
+
+## Content rules
+
+- **First person, past tense, honest.** "I tried X, it fell apart because Y" — never marketing tone, never "we are pleased to".
+- **Record the dead ends.** A reversal ("first instinct was forks; landed on worktrees") is the most valuable content, not something to edit out.
+- **Be concrete.** Link the actual PRs and issues, quote the actual numbers, use tables for measured data. A claim that was verified says where it was verified.
+- **Distinguish who did what.** What the agent proposed, what the human corrected, what was checked against the code.
+- **Never rewrite history.** Past sections stay as written; if a past conclusion turned out wrong, add a new section saying so (that reversal is content).
+
+## The header block
+
+Every making-of opens with:
+
+1. A title that states the project and the angle (e.g. "Building X: a Y, one prompt at a time").
+2. An italic paragraph saying what the document is, its style ("journal, not docs"), who it is for, and its update policy ("updated on request as the work progresses").
+3. A `*Last updated: YYYY-MM-DD.*` line, refreshed on every edit.
+
+## Usage
+
+- **Bootstrap**: ask the agent to "create a making-of for this project" — it reads the git history and any prior conversation context to draft the first entry.
+- **Session updates**: at the end of a work session, say "update the making-of" — the agent appends what happened since the last update.
+
+See [`prompt.md`](prompt.md) for the agent-ready instructions and [`templates/`](templates/) for the file skeletons.
+
+## Customization
+
+| What to change | How |
+|----------------|-----|
+| File name | Default `MAKING-OF.md`; use `making-of-<author>.md` when several people keep separate journals in one repo |
+| Language | Match the language the author uses with the agent (the journal is personal, not project docs) |
+| Location | Repository root by default; a subdirectory main file works too |
+| Versioning | Usually committed; can be kept untracked if the journal is personal (note it in the intro block) |
+
+## Example usage
+
+See [`examples/example-usage.md`](examples/example-usage.md).

--- a/skills/documentation/making-of/README.md
+++ b/skills/documentation/making-of/README.md
@@ -9,10 +9,11 @@ Formal docs explain **what** the project is. A making-of records **how it came t
 ## What it does
 
 1. Creates a `MAKING-OF.md` at the repository root (or adds a new entry to an existing one).
-2. Writes in the **author's first-person voice** — the human's journal, drafted by the agent.
-3. At the end of a work session, appends a new section covering what happened since the last update: decisions, dead ends, links to PRs/issues, measured numbers.
-4. Updates the **Last updated** date on every edit.
-5. When the file grows too large, splits into one post per milestone under `doc/making-of/`, with the root file becoming an index.
+2. Writes in the **author's first-person voice**, in **blog style** — narrative prose meant to be read, not a changelog. The human's journal, drafted by the agent.
+3. At the end of a work session, appends a new section covering what happened since the last update: what was done, the discussions with the LLM (proposals, pushback, corrections), decisions, dead ends, links to PRs/issues, measured numbers.
+4. When code was generated, includes **proof that it works**: a snippet of the generated test, an explanation of why that test proves the fix, and the real output of running it.
+5. Updates the **Last updated** date on every edit.
+6. When the file grows too large, splits into one post per milestone under `doc/making-of/`, with the root file becoming an index.
 
 ## The two layouts
 
@@ -25,10 +26,12 @@ Start with the single document. Split only when a section boundary is natural (a
 
 ## Content rules
 
+- **Blog style.** Narrative prose with full sentences and section titles that read like hooks, not labels — text that could be published as a blog post as-is. Never a changelog or a bullet list of commits.
 - **First person, past tense, honest.** "I tried X, it fell apart because Y" — never marketing tone, never "we are pleased to".
 - **Record the dead ends.** A reversal ("first instinct was forks; landed on worktrees") is the most valuable content, not something to edit out.
+- **Record the conversation.** The back-and-forth with the LLM is part of the story: what was proposed, what the author corrected, how the disagreement resolved.
+- **Show proof, not claims.** When code was generated, the journal shows the evidence: the test snippet, why passing it proves the behavior is correct, and the real output of the test run — not just "it works now".
 - **Be concrete.** Link the actual PRs and issues, quote the actual numbers, use tables for measured data. A claim that was verified says where it was verified.
-- **Distinguish who did what.** What the agent proposed, what the human corrected, what was checked against the code.
 - **Never rewrite history.** Past sections stay as written; if a past conclusion turned out wrong, add a new section saying so (that reversal is content).
 
 ## The header block

--- a/skills/documentation/making-of/examples/example-usage.md
+++ b/skills/documentation/making-of/examples/example-usage.md
@@ -23,25 +23,48 @@ At the end of a work session:
 Update the making-of.
 ```
 
-The agent appends new sections covering the session and refreshes the date. A typical appended section:
+The agent appends new sections covering the session and refreshes the date. A typical appended section — note the three beats: what was done, the discussion with the LLM, and proof the generated code works:
 
-```markdown
-## Turns out the install script itself needed fixes first
+````markdown
+## The off-by-one in the interpolator, and the test that pins it down
 
-Before a single data point existed, just getting `00-install.sh` to pass
-green surfaced two real issues in the tool itself:
+Today's session was supposed to be about locale bundles. It turned into
+chasing [#42](https://github.com/example/tool/issues/42): messages like
+`{min} must be under {max}` interpolated the last placeholder as `{max`
+— one character short.
 
-- **[#17](https://github.com/example/tool/issues/17)** — the README's
-  install command 404s, because release assets are version-prefixed but the
-  documented command hardcodes an unversioned filename. **Fixed and merged**
-  in [PR #21](https://github.com/example/tool/pull/21).
-- **[#19](https://github.com/example/tool/issues/19)** — a request sent
-  before the init notification is silently dropped. Traced it into the
-  upstream SDK, which has a `TODO` acknowledging the exact gap. A dead end
-  worth recording: not our bug, reported upstream.
+Claude's first diagnosis blamed the regex. I pushed back: the same regex
+works fine on single-placeholder messages, so the bug had to be in how the
+scan resumes after a match. Second pass found it — the loop resumed at
+`end` instead of `end + 1`, eating the closing brace of the *next*
+placeholder. The regex was innocent.
+
+The fix only counts once a test pins it down. Here is the one Claude
+generated:
+
+```java
+@Test
+void interpolatesConsecutivePlaceholders() {
+    var result = interpolator.interpolate("{min} must be under {max}",
+            Map.of("min", "1", "max", "10"));
+    assertEquals("1 must be under 10", result);
+}
 ```
 
-Note the pattern: first person, concrete links, a dead end recorded as content.
+This proves it because the failure only appears from the second
+placeholder onward: before the fix this exact assertion failed with
+`"1 must be under {max"` (I ran it against the pre-fix code to check),
+so a green run means the scan-resume bug is gone — not just that the
+code compiles. Running it:
+
+```text
+$ mvn test -Dtest=MessageInterpolatorTest
+[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0
+[INFO] BUILD SUCCESS
+```
+````
+
+First person, blog-style prose, the disagreement with the LLM recorded (the wrong first diagnosis is content, not noise), and the proof shown in full: test snippet, why it proves the fix, real runner output.
 
 ## Sample header block (what the top of the file looks like)
 

--- a/skills/documentation/making-of/examples/example-usage.md
+++ b/skills/documentation/making-of/examples/example-usage.md
@@ -1,0 +1,86 @@
+# Example Usage: making-of
+
+## When to use this skill
+
+Use this skill on any project built with AI-assisted sessions where the reasoning is worth keeping: why decisions were made, what was tried and abandoned, what was measured. It replaces "the git log knows what changed" with "the journal knows why".
+
+## Bootstrap
+
+At the start (or any point) of a project, tell the agent:
+
+```text
+Create a making-of for this project. Follow skills/documentation/making-of/prompt.md.
+Start from the git history and what we did in this session.
+```
+
+The agent creates `MAKING-OF.md` from the template, drafts "Why this exists" and the first sections, and asks about anything it cannot reconstruct from the repository.
+
+## End-of-session update
+
+At the end of a work session:
+
+```text
+Update the making-of.
+```
+
+The agent appends new sections covering the session and refreshes the date. A typical appended section:
+
+```markdown
+## Turns out the install script itself needed fixes first
+
+Before a single data point existed, just getting `00-install.sh` to pass
+green surfaced two real issues in the tool itself:
+
+- **[#17](https://github.com/example/tool/issues/17)** — the README's
+  install command 404s, because release assets are version-prefixed but the
+  documented command hardcodes an unversioned filename. **Fixed and merged**
+  in [PR #21](https://github.com/example/tool/pull/21).
+- **[#19](https://github.com/example/tool/issues/19)** — a request sent
+  before the init notification is silently dropped. Traced it into the
+  upstream SDK, which has a `TODO` acknowledging the exact gap. A dead end
+  worth recording: not our bug, reported upstream.
+```
+
+Note the pattern: first person, concrete links, a dead end recorded as content.
+
+## Sample header block (what the top of the file looks like)
+
+```markdown
+# Building Erasmus: a Jakarta Bean Validation implementation, one prompt at a time
+
+*A first-person account of how this project came together — the tooling, the
+false starts, and the implementation work — kept here for new contributors,
+or anyone curious how it came together. Written in a blog-ish style rather
+than as formal docs; may still turn into an actual blog post at some point.
+Updated on request as the work progresses.*
+
+*Last updated: 2026-08-19.*
+```
+
+## Splitting into a post series
+
+When the file gets long and a milestone ships, tell the agent:
+
+```text
+The making-of is getting long. Split it into per-milestone posts under
+doc/making-of/ and turn MAKING-OF.md into an index.
+```
+
+The resulting index body:
+
+```markdown
+## Posts
+
+1. [Kicking off Erasmus: from an empty reactor to a working validator](doc/making-of/01-kicking-off-erasmus.md) —
+   the tooling detour, cloning the workspace, the first two prompts, and
+   milestones M0 (scaffolding) + M1 (the first 6 built-in constraints).
+2. [M2: the full built-in constraint set and message interpolation](doc/making-of/02-full-constraint-set.md) —
+   the remaining 15 constraints, locale-aware bundles, and a homegrown
+   EL-subset evaluator.
+```
+
+## Variations
+
+- **Per-author journal**: in a shared repo, name the file `making-of-<author>.md` so each contributor keeps their own voice.
+- **Untracked journal**: if the journal is personal, keep it out of version control and say so in the intro block ("Not versioned in the repository for now.").
+- **Language**: the journal is written in whatever language the author works in with the agent (e.g. French), even if project docs are in English.

--- a/skills/documentation/making-of/prompt.md
+++ b/skills/documentation/making-of/prompt.md
@@ -21,15 +21,31 @@ Maintain a making-of journal for this repository: a first-person, blog-ish accou
 
 - Read the whole file first and match its voice, language, and formatting exactly.
 - Append one or more new `##` sections covering what happened since the last update. Do not pad: if the session produced one decision, write one short section.
+- Each update must cover three things:
+  1. **What was done** — the changes, decisions, and outcomes of the session.
+  2. **The discussions with the LLM** — what the agent proposed, what the author pushed back on or corrected, and how the disagreement resolved. A correction the author made to the agent's first answer is prime content.
+  3. **Proof that generated code works** — see "Show proof, not claims" below. If code was written this session, the update is not complete without its evidence.
 - Update the `*Last updated:*` date. Change nothing else in the header block.
 - Never rewrite or delete past sections. If a past conclusion turned out wrong, say so in the new section — the reversal is the content.
 
+## Show proof, not claims
+
+When a session produced generated code (a fix, a feature), never just state that it works. Include the evidence, as a reader would need it to believe you:
+
+- **A snippet of the test** that exercises the change — the generated test itself, trimmed to the relevant assertion, in a fenced code block.
+- **Why this test proves it** — one or two sentences connecting the assertion to the bug or requirement: what would have failed before the change, and why passing now means the behavior is correct (not just that the code runs).
+- **The actual output of running it** — the real test-runner output (trimmed), in a fenced code block. A green run that was actually executed, not a description of one. If the test was also run against the pre-fix code to show it failing, include that red output too — it is the strongest proof.
+
+If the change cannot be proven by a test (docs, config), show the equivalent evidence: the command run and its real output.
+
 ## Content rules (both modes)
 
+- **Blog style, not changelog style.** Full sentences and narrative flow, written to be read — the kind of text that could be published as a blog post as-is. Section titles are statements or hooks ("Turns out the install script needed fixes first"), not labels ("Fixes"). No bare bullet lists of commits.
 - **First person, past tense, honest.** The human author's journal, drafted by you. No marketing tone, no "we are excited to".
 - **Record reasoning, not just outcomes.** What was tried first, why it fell apart, what was landed on instead. Dead ends get their own paragraphs.
+- **Record the conversation.** The back-and-forth with the LLM is part of the story: what was asked, what the agent got wrong, what the author corrected. Quote the pivotal exchange when it explains a decision.
+- **Show proof, not claims.** Generated code is only "done" in the journal when the evidence is shown (see the section above).
 - **Be concrete.** Link actual PRs, issues, and files; quote measured numbers; use tables for data. When a claim was verified, say against what.
-- **Distinguish roles.** What the agent proposed, what the human corrected or decided, what was checked against the code.
 - **Keep it readable in one sitting.** Sections short, one idea each.
 
 ## Splitting into a post series

--- a/skills/documentation/making-of/prompt.md
+++ b/skills/documentation/making-of/prompt.md
@@ -1,0 +1,41 @@
+# Prompt: Maintain a Making-Of Journal
+
+Use this prompt to instruct an AI agent to create or update a first-person making-of journal in a repository.
+
+---
+
+Maintain a making-of journal for this repository: a first-person, blog-ish account of how the project is being built, written in the author's voice, for new contributors and anyone curious how it came together.
+
+## If the file does not exist yet (bootstrap)
+
+- Create `MAKING-OF.md` at the repository root. Copy the skeleton from `skills/documentation/making-of/templates/MAKING-OF.md`.
+- Open with the three-part header block:
+  1. A title stating the project and the angle (pattern: "Building <project>: <what it is>, one prompt at a time").
+  2. An italic intro paragraph: what this document is, its style ("a first-person log / journal, not formal docs — kept for the reasoning, including the dead ends and reversals"), who it is for, and its update policy ("updated on request as the work progresses").
+  3. A `*Last updated: YYYY-MM-DD.*` line.
+- Write the first section as "Why this exists": the motivation or the triggering event, in the author's voice.
+- Draft the initial entries from the git history, existing issues/PRs, and the current conversation. Ask the author about anything you cannot reconstruct (motivations, off-repo events) instead of inventing it.
+- Write in the language the author uses when talking to you.
+
+## If the file exists (end-of-session update)
+
+- Read the whole file first and match its voice, language, and formatting exactly.
+- Append one or more new `##` sections covering what happened since the last update. Do not pad: if the session produced one decision, write one short section.
+- Update the `*Last updated:*` date. Change nothing else in the header block.
+- Never rewrite or delete past sections. If a past conclusion turned out wrong, say so in the new section — the reversal is the content.
+
+## Content rules (both modes)
+
+- **First person, past tense, honest.** The human author's journal, drafted by you. No marketing tone, no "we are excited to".
+- **Record reasoning, not just outcomes.** What was tried first, why it fell apart, what was landed on instead. Dead ends get their own paragraphs.
+- **Be concrete.** Link actual PRs, issues, and files; quote measured numbers; use tables for data. When a claim was verified, say against what.
+- **Distinguish roles.** What the agent proposed, what the human corrected or decided, what was checked against the code.
+- **Keep it readable in one sitting.** Sections short, one idea each.
+
+## Splitting into a post series
+
+When the single file no longer reads in one sitting **and** a natural boundary exists (a milestone shipped):
+
+- Move the body into `doc/making-of/NN-<slug>.md` posts (copy the post skeleton from `skills/documentation/making-of/templates/making-of-post.md`).
+- Turn the root `MAKING-OF.md` into an index: keep the header block, replace the body with a numbered "Posts" list, one line per post with a link and a one-sentence summary of what it covers.
+- New milestones get new posts; the index gets one new line.

--- a/skills/documentation/making-of/templates/MAKING-OF.md
+++ b/skills/documentation/making-of/templates/MAKING-OF.md
@@ -1,0 +1,39 @@
+# Building <project>: <what it is>, one prompt at a time
+
+*A first-person account of how this project came together — the tooling, the false starts,
+and the implementation work — kept here for new contributors, or anyone curious how it came
+together. Written in a blog-ish style rather than as formal docs; may still turn into an
+actual blog post at some point. Updated on request as the work progresses.*
+
+*Last updated: YYYY-MM-DD.*
+
+## Why this exists
+
+<!-- The motivation or triggering event, in the author's voice. What question is this
+project answering? What happened that made it start? -->
+
+## <First theme or decision, as a statement — e.g. "Designing the experiment: forks, then worktrees">
+
+<!-- What was tried first, why it fell apart, what was landed on instead. Reversals are the
+most valuable content — keep them. -->
+
+## <Next section — one idea per section>
+
+<!-- Be concrete: link the actual PRs/issues, quote the measured numbers, use tables for
+data. Say what the agent proposed vs. what the human corrected. -->
+
+<!--
+At the end of each work session: append new ## sections covering what happened, update the
+"Last updated" date, and never rewrite past sections — if a past conclusion turned out
+wrong, say so in a new section.
+
+When this file no longer reads in one sitting and a milestone boundary exists, split into
+doc/making-of/NN-slug.md posts and turn this file into an index:
+
+## Posts
+
+1. [Kicking off <project>: <subtitle>](doc/making-of/01-kicking-off.md) —
+   one sentence on what the post covers.
+2. [<Milestone>: <subtitle>](doc/making-of/02-milestone.md) —
+   one sentence on what the post covers.
+-->

--- a/skills/documentation/making-of/templates/MAKING-OF.md
+++ b/skills/documentation/making-of/templates/MAKING-OF.md
@@ -20,10 +20,29 @@ most valuable content — keep them. -->
 ## <Next section — one idea per section>
 
 <!-- Be concrete: link the actual PRs/issues, quote the measured numbers, use tables for
-data. Say what the agent proposed vs. what the human corrected. -->
+data. Recount the discussion with the LLM: what it proposed, what I corrected, how it
+resolved. -->
+
+<!-- When the session generated code, show proof it works — the pattern is always the same
+three beats:
+
+The fix only counts once a test pins it down. Here is the one Claude generated:
+
+```<lang>
+<the generated test, trimmed to the relevant assertion>
+```
+
+This proves it because <what would have failed before the change, and why passing now
+means the behavior is correct>. Running it:
+
+```text
+<real test-runner output, trimmed — actually executed, not described>
+```
+-->
 
 <!--
-At the end of each work session: append new ## sections covering what happened, update the
+At the end of each work session: append new ## sections covering (1) what was done,
+(2) the discussions with the LLM, (3) proof that generated code works. Update the
 "Last updated" date, and never rewrite past sections — if a past conclusion turned out
 wrong, say so in a new section.
 

--- a/skills/documentation/making-of/templates/making-of-post.md
+++ b/skills/documentation/making-of/templates/making-of-post.md
@@ -1,0 +1,18 @@
+# <Milestone or theme>: <subtitle stating what shipped or what was learned>
+
+<!-- One post per milestone (or milestone group), stored as doc/making-of/NN-slug.md and
+linked from the root MAKING-OF.md index. Same voice and rules as the main file: first
+person, past tense, honest, concrete. -->
+
+## <Section — one idea, stated as a claim or event>
+
+<!-- What was tried, what broke, what was decided. Link PRs/issues, quote numbers. -->
+
+## <Dead end worth recording>
+
+<!-- Dead ends get their own sections — they are the content, not noise. Say how far the
+trail was followed and why it stopped. -->
+
+## <What's next>
+
+<!-- Optional: the open questions this post hands to the next one. -->

--- a/skills/index.md
+++ b/skills/index.md
@@ -2,6 +2,12 @@
 
 A complete list of available skills in this library. Search this file before creating a new implementation.
 
+## Documentation
+
+| Skill | Description |
+|-------|-------------|
+| [making-of](documentation/making-of/README.md) | Maintain a first-person making-of journal recording how a project is built — decisions, dead ends, and reversals — updated at the end of each AI-assisted session |
+
 ## GitHub Actions
 
 | Skill | Description |


### PR DESCRIPTION
## What

Adds a new skill under a new **Documentation** category: `skills/documentation/making-of/`.

The skill instructs an AI agent to maintain a first-person "making-of" journal in a repository — a blog-style account of how the project is being built, written in the author's voice and updated at the end of each AI-assisted work session.

## Why

Formal docs explain *what* a project is; a making-of records *how it came together*: the reasoning, the measurements, the false starts, and the reversals. The pattern was distilled from three real journals maintained this way across different projects.

## Key content rules

- **Blog style** — narrative prose meant to be read (publishable as a blog post as-is), never a changelog or a bullet list of commits.
- **Each session update covers three beats**: what was done, the discussions with the LLM (proposals, pushback, corrections — a wrong first diagnosis is content), and proof that generated code works.
- **Show proof, not claims** — when code was generated, the journal includes the generated test snippet, an explanation of why passing it proves the fix is correct (what would have failed before), and the real output of the test run.
- Append-only history: past sections are never rewritten; reversals get new sections.

## Contents

- `README.md` — the pattern, the two layouts (single living document vs. per-milestone post series), content rules, customization
- `prompt.md` — agent-ready instructions: bootstrap mode, end-of-session update mode (the three beats), and the "Show proof, not claims" section
- `templates/MAKING-OF.md` and `templates/making-of-post.md` — skeletons with the three-part header block and the proof pattern inline
- `examples/example-usage.md` — bootstrap/update prompts and a full worked session entry showing an LLM disagreement recorded plus a test snippet, its justification, and the runner output
- `skills/index.md` and root `README.md` updated with the new category and entry

## Checklist

- [x] All required files present (README, prompt, templates, example)
- [x] Documentation in English, follows `standards/markdown-style.md`
- [x] Skill index updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)