### PR TITLE
feat: adopt Agent Skills format and become a Claude Code plugin marketplace

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,19 @@
+{
+  "name": "sunix-ai-skills",
+  "owner": {
+    "name": "Sun S. D. Tan",
+    "url": "https://github.com/sunix"
+  },
+  "metadata": {
+    "description": "Reusable AI-agent skills library: GitHub Actions workflows (Surge deploys, PR previews, release-please), webapp snippets, and documentation practices (making-of journals).",
+    "version": "1.0.0"
+  },
+  "plugins": [
+    {
+      "name": "ai-skills",
+      "source": "./",
+      "description": "All skills from the ai-skills library: Surge deploys and PR previews, release-please automation, GitHub star button, making-of journals.",
+      "category": "productivity"
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,17 @@
+{
+  "name": "ai-skills",
+  "description": "Reusable AI-agent skills: GitHub Actions workflows (Surge deploys, PR previews, release-please), webapp snippets, and documentation practices (making-of journals).",
+  "version": "1.0.0",
+  "author": {
+    "name": "Sun S. D. Tan",
+    "url": "https://github.com/sunix"
+  },
+  "homepage": "https://github.com/sunix/ai-skills",
+  "repository": "https://github.com/sunix/ai-skills",
+  "license": "MIT",
+  "skills": [
+    "./skills/github-actions",
+    "./skills/webapp",
+    "./skills/documentation"
+  ]
+}

--- a/AGENT_GUIDE.md
+++ b/AGENT_GUIDE.md
@@ -22,11 +22,12 @@ This guide defines how an AI coding agent should use this repository.
 
 1. Create a directory under `skills/<category>/<skill-name>/` using kebab-case.
 2. Add the required files (see [CONTRIBUTING.md](CONTRIBUTING.md)):
+   - `SKILL.md` (Agent Skills format: frontmatter `name`/`description` + condensed instructions)
    - `README.md`
    - `prompt.md`
    - `templates/<template-file>`
    - `examples/example-usage.md`
-3. Add an entry to [`skills/index.md`](skills/index.md).
+3. Add an entry to [`skills/index.md`](skills/index.md). If the category is new, add its directory to the `skills` array in `.claude-plugin/plugin.json`.
 4. Follow the style rules in [`standards/markdown-style.md`](standards/markdown-style.md).
 5. Open a pull request.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,10 +13,22 @@ Thank you for contributing to ai-skills. Follow these guidelines to keep the lib
 
 | File | Purpose |
 |------|---------|
+| `SKILL.md` | [Agent Skills](https://agentskills.my/specification/) entry point: YAML frontmatter (`name`, `description`) + condensed agent instructions. This is what skill tooling (Claude Code plugins, `gh skill`, `npx skills`) discovers and loads |
 | `README.md` | Human-readable explanation, prerequisites, usage, and customization notes |
 | `prompt.md` | AI-agent-ready prompt that instructs an agent to apply the skill |
 | `templates/<file>` | One or more copyable implementation files (YAML, scripts, configs, etc.) |
 | `examples/example-usage.md` | Concrete examples showing the skill in action |
+
+### SKILL.md requirements
+
+- Frontmatter: `name` (kebab-case, matching the directory name) and `description` (one or two sentences stating what the skill does **and when to use it** — agents match on this text).
+- Body: condensed instructions linking to `prompt.md`, `templates/`, and `README.md` by relative path.
+- If you create a **new category** directory, also add it to the `skills` array in [`.claude-plugin/plugin.json`](.claude-plugin/plugin.json) — skill discovery scans each listed category directory one level deep.
+- Verify discovery before opening the PR:
+  ```bash
+  claude plugin validate .
+  claude --plugin-dir . plugin details ai-skills   # your skill must appear in the inventory
+  ```
 
 ## Documentation requirements
 

--- a/README.md
+++ b/README.md
@@ -6,10 +6,32 @@ A reusable skills library for AI coding agents such as GitHub Copilot, Claude Co
 
 A skill is a self-contained, documented, and directly reusable implementation pattern. Each skill includes:
 
+- A `SKILL.md` in the open [Agent Skills](https://agentskills.my/specification/) format, discoverable by skill tooling
 - A `README.md` explaining what it does and how to use it
 - A `prompt.md` written for AI agents to consume directly
 - One or more implementation files or templates
 - Concrete examples that can be copied into another repository
+
+## Installing these skills in your projects
+
+The repository is a **Claude Code plugin marketplace**. In Claude Code:
+
+```
+/plugin marketplace add sunix/ai-skills
+/plugin install ai-skills@sunix-ai-skills
+```
+
+All skills then load automatically (invoke them as `/ai-skills:making-of`, `/ai-skills:release-please`, etc.).
+
+Because every skill follows the open Agent Skills format, generic skill installers work too:
+
+```bash
+# GitHub CLI (v2.90+)
+gh skill install sunix/ai-skills making-of
+
+# npx skills (installs into .claude/skills/ or .agents/skills/)
+npx skills add sunix/ai-skills
+```
 
 ## Purpose
 

--- a/skills/documentation/making-of/SKILL.md
+++ b/skills/documentation/making-of/SKILL.md
@@ -1,0 +1,30 @@
+---
+name: making-of
+description: Create or update a first-person, blog-style "making-of" journal (MAKING-OF.md) recording how a project is built with AI assistance — decisions, LLM discussions, dead ends, and proof that generated code works. Use when the user says "update the making-of", "create a making-of", or wants a development journal/log of AI-assisted sessions.
+---
+
+# Maintain a making-of journal
+
+Maintain a making-of journal for the current repository: a first-person, blog-style account of how the project is being built, written in the author's voice.
+
+## If `MAKING-OF.md` does not exist (bootstrap)
+
+Create it at the repository root from [templates/MAKING-OF.md](templates/MAKING-OF.md): a three-part header (title "Building X: ..., one prompt at a time"; italic intro stating what the document is, its journal style, audience, and update policy; a `*Last updated: YYYY-MM-DD.*` line), then a "Why this exists" section. Draft initial entries from git history and the current conversation; ask the author about anything you cannot reconstruct instead of inventing it. Write in the language the author uses with you.
+
+## If it exists (end-of-session update)
+
+Read the whole file, match its voice and language, and append new `##` sections covering three beats:
+
+1. **What was done** — changes, decisions, outcomes.
+2. **The discussions with the LLM** — what was proposed, what the author pushed back on or corrected, how it resolved. A wrong first diagnosis is content, not noise.
+3. **Proof that generated code works** — the generated test snippet (trimmed to the relevant assertion), one or two sentences on why passing it proves the fix (what failed before), and the real test-runner output. Include the red pre-fix run when available. For untestable changes, show the command run and its real output.
+
+Update the `*Last updated:*` date. Never rewrite or delete past sections — a reversed conclusion gets a new section saying so.
+
+## Style rules
+
+Blog style: narrative prose meant to be read, section titles as hooks not labels, never a changelog or commit list. First person, past tense, honest, no marketing tone. Concrete: link real PRs/issues, quote measured numbers.
+
+When the file no longer reads in one sitting and a milestone boundary exists, split into `doc/making-of/NN-slug.md` posts ([templates/making-of-post.md](templates/making-of-post.md)) and turn the root file into an index.
+
+Full instructions: [prompt.md](prompt.md). Worked example with the proof pattern: [examples/example-usage.md](examples/example-usage.md).

--- a/skills/github-actions/pr-preview-surge/SKILL.md
+++ b/skills/github-actions/pr-preview-surge/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: pr-preview-surge
+description: Add a GitHub Actions workflow that deploys a pull request preview of a static site to Surge when someone comments /preview on the PR, and posts the preview URL back as a PR comment. Use when the user wants PR preview deployments or review apps for a static site on Surge.
+---
+
+# PR preview deployments to Surge
+
+Add a GitHub Actions workflow to the current repository that deploys a pull request preview to Surge when a `/preview` comment is posted on the PR.
+
+Copy [templates/preview-pr.yml](templates/preview-pr.yml) to `.github/workflows/preview-pr.yml` in the target repository, then adapt it:
+
+- Trigger on `issue_comment` created events; run only when the comment contains `/preview` and is on a pull request. Validate the PR is mergeable before deploying (never deploy a stale merge ref).
+- Post an "in progress" PR comment immediately (capture its ID), check out `refs/pull/{PR_NUMBER}/merge`, build, deploy to `pr-{PR_NUMBER}-<project>.surge.sh`, then **update** that same comment with the preview URL on success or the failed run link on failure.
+- Detect the build toolchain (Jekyll, Hugo, Vite/Next.js, Quarkus Roq/Maven) and keep only the setup/build steps it needs — same detection table as the `push-to-surge` skill.
+- Validate the `SURGE_TOKEN` secret exists, failing with instructions if missing.
+- Concurrency control scoped to the PR number; minimal permissions (`contents: read`, `pull-requests: write`); build steps inline.
+
+Full requirements list: [prompt.md](prompt.md). Human documentation: [README.md](README.md).

--- a/skills/github-actions/push-to-surge/SKILL.md
+++ b/skills/github-actions/push-to-surge/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: push-to-surge
+description: Add a GitHub Actions workflow that deploys a static site (Jekyll, Hugo, Vite, Next.js, Quarkus Roq...) to Surge on every push to the main branch. Use when the user wants continuous deployment of a static site to Surge or a surge.sh URL updated on each push.
+---
+
+# Deploy to Surge on push to main
+
+Add a GitHub Actions workflow to the current repository that deploys a static site to Surge whenever code is pushed to the `main` branch.
+
+Copy [templates/deploy-main.yml](templates/deploy-main.yml) to `.github/workflows/deploy-main.yml` in the target repository, then adapt it:
+
+- Detect the project's build toolchain and keep only the setup/build steps it requires:
+  - **Jekyll**: Ruby 3.1, Graphviz, Node.js 20; build with `bundle exec jekyll build` (`JEKYLL_ENV: production`); publish `_site`.
+  - **Quarkus Roq / Maven**: Java + Maven; build with `mvn package -DskipTests`; publish the generated static output directory.
+  - **Node.js (Vite, Next.js, etc.)**: Node.js 20; `npm ci && npm run build`; publish `dist` or `out`.
+  - **Hugo**: build with `hugo`; publish `public`.
+  - Unknown toolchain: default to Node.js 20 with `npm ci && npm run build`.
+- Keep the validation step that checks `SURGE_TOKEN` and `SURGE_DOMAIN` secrets exist, failing with instructions on how to create them (see [README.md](README.md) for the token generation steps to include).
+- Deploy with explicit `--domain` and `--token` flags; minimal permissions (`contents: read`); build steps inline, no composite actions.
+
+Full requirements list: [prompt.md](prompt.md). Human documentation and customization table: [README.md](README.md).

--- a/skills/github-actions/release-please/SKILL.md
+++ b/skills/github-actions/release-please/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: release-please
+description: Add a GitHub Actions workflow that automates semantic versioning, changelogs, and GitHub Releases using release-please and Conventional Commits. Use when the user wants automated releases, version bumps, release PRs, or changelog generation on a GitHub repository.
+---
+
+# Automated releases with release-please
+
+Add a GitHub Actions workflow to the current repository that uses [release-please](https://github.com/googleapis/release-please) to automate versioning and GitHub Releases.
+
+Copy [templates/release-please.yml](templates/release-please.yml) to `.github/workflows/release-please.yml` in the target repository. Key points to preserve:
+
+- Trigger on `push` to `main`; single step using `googleapis/release-please-action@v4`.
+- Permissions: `contents: write` and `pull-requests: write` (the minimum release-please needs).
+- Token: `${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}` — a PAT lets the published release trigger downstream `on: release` workflows (the default `GITHUB_TOKEN` cannot, due to GitHub's anti-loop safeguard); the fallback keeps it zero-setup.
+- Do not add `release-please-config.json` / `.release-please-manifest.json` unless the user explicitly asks for multi-package or custom configuration.
+
+Then update the project's agent instruction file (`AGENT.md`, `CLAUDE.md`, `.github/copilot-instructions.md` — whichever exists, else create `AGENT.md`) to enforce **Conventional Commits** (`feat:` → minor, `fix:` → patch, `feat!:`/`BREAKING CHANGE:` → major) for commits and PR titles, and one logical commit per PR.
+
+Full requirements list: [prompt.md](prompt.md). Human documentation: [README.md](README.md).

--- a/skills/webapp/github-star-button/SKILL.md
+++ b/skills/webapp/github-star-button/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: github-star-button
+description: Add a GitHub star button with a live star count to a web page, using plain JavaScript and the public GitHub API. Use when the user wants to display a repository's star count or a "Star on GitHub" link/badge on a website.
+---
+
+# GitHub star button with live count
+
+Add a star button to the current web page that shows the live GitHub star count and links visitors to the repository.
+
+Copy the snippet from [templates/github-star-button.html](templates/github-star-button.html) into the page where the button should appear (header, footer, or sidebar), replacing `{owner}` and `{repo}`:
+
+- An anchor to `https://github.com/{owner}/{repo}` with `target="_blank"` and `rel="noopener noreferrer"`, labeled with a ⭐ icon, the text **Star**, and a `<span>` for the count.
+- On page load, fetch `https://api.github.com/repos/{owner}/{repo}` (unauthenticated, `encodeURIComponent` on both parts) and fill the `<span>` with `stargazers_count` formatted as `(N)`.
+- On any API failure (network, rate limit), leave the count empty and keep the link functional — log to console, show nothing to the user.
+- Plain JavaScript only, no libraries, no CSS (inherit the page's styles).
+
+Full requirements list: [prompt.md](prompt.md). Human documentation: [README.md](README.md).


### PR DESCRIPTION
## What

Two changes that make every skill in this library installable in other projects with existing tooling — no custom CLI needed:

### 1. A `SKILL.md` per skill (open [Agent Skills](https://agentskills.my/specification/) format)

Each of the five skills gets a `SKILL.md` with YAML frontmatter (`name`, trigger-rich `description`) and condensed agent instructions linking to the skill's `prompt.md`, `templates/`, and `README.md`. This makes them discoverable by Claude Code, `gh skill` (GitHub CLI v2.90+), `npx skills`, and other tools implementing the standard.

### 2. The repo becomes a Claude Code plugin marketplace

- `.claude-plugin/marketplace.json` — the marketplace, exposing a single `ai-skills` plugin sourced from the repo root.
- `.claude-plugin/plugin.json` — the plugin manifest. Nested skill discovery is not supported by Claude Code, but the `skills` array accepts additional directories (each scanned one level deep), so listing the three category directories keeps the existing `skills/<category>/<name>/` layout unchanged.

Usage after merge:

```
/plugin marketplace add sunix/ai-skills
/plugin install ai-skills@sunix-ai-skills
```

## Verification

```
$ claude plugin validate .
✔ Validation passed

$ claude --plugin-dir . plugin details ai-skills
Skills (5)  github-star-button, making-of, pr-preview-surge, push-to-surge, release-please
Always-on:  ~518 tok
```

All five skills are discovered through the categorized layout.

## Docs

- README: new "Installing these skills in your projects" section (plugin marketplace, `gh skill`, `npx skills`) and `SKILL.md` added to the skill anatomy.
- CONTRIBUTING: `SKILL.md` added to required files, with frontmatter rules, the new-category → `plugin.json` step, and the validation commands to run before a PR.
- AGENT_GUIDE: required-files list updated accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)