### PR TITLE
feat(making-of): goal-first entries, oracle proofs, code walkthroughs, no meta-narration

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Reusable AI-agent skills library: GitHub Actions workflows (Surge deploys, PR previews, release-please), webapp snippets, and documentation practices (making-of journals).",
-    "version": "1.0.0"
+    "version": "1.1.0"
   },
   "plugins": [
     {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ai-skills",
   "description": "Reusable AI-agent skills: GitHub Actions workflows (Surge deploys, PR previews, release-please), webapp snippets, and documentation practices (making-of journals).",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "author": {
     "name": "Sun S. D. Tan",
     "url": "https://github.com/sunix"

--- a/skills/documentation/making-of/README.md
+++ b/skills/documentation/making-of/README.md
@@ -29,8 +29,11 @@ Start with the single document. Split only when a section boundary is natural (a
 - **Blog style.** Narrative prose with full sentences and section titles that read like hooks, not labels — text that could be published as a blog post as-is. Never a changelog or a bullet list of commits.
 - **First person, past tense, honest.** "I tried X, it fell apart because Y" — never marketing tone, never "we are pleased to".
 - **Record the dead ends.** A reversal ("first instinct was forks; landed on worktrees") is the most valuable content, not something to edit out.
+- **Goal first, with a concrete example.** Every session or milestone entry opens with what it set out to accomplish, shown concretely (the input the user writes, the command they run, the result they should get), before any how.
 - **Record the conversation.** The back-and-forth with the LLM is part of the story: what was proposed, what the author corrected, how the disagreement resolved.
-- **Show proof, not claims.** When code was generated, the journal shows the evidence: the test snippet, why passing it proves the behavior is correct, and the real output of the test run — not just "it works now".
+- **Show proof, not claims.** When code was generated, the journal shows the evidence: the test snippet, why passing it proves the behavior is correct, and the real output of the test run — not just "it works now". Prefer oracle-based proofs (test against a reference tool's answer) over hardcoded expected values.
+- **Walk through interesting code.** Quote the load-bearing snippets and explain why they are written that way — the reader should come away understanding the code's ideas, not just that it exists.
+- **No meta-narration.** The journal never discusses its own writing or updating (exception: a repo whose subject is the making-of practice itself, like this skill's repo).
 - **Be concrete.** Link the actual PRs and issues, quote the actual numbers, use tables for measured data. A claim that was verified says where it was verified.
 - **Never rewrite history.** Past sections stay as written; if a past conclusion turned out wrong, add a new section saying so (that reversal is content).
 

--- a/skills/documentation/making-of/SKILL.md
+++ b/skills/documentation/making-of/SKILL.md
@@ -13,17 +13,22 @@ Create it at the repository root from [templates/MAKING-OF.md](templates/MAKING-
 
 ## If it exists (end-of-session update)
 
-Read the whole file, match its voice and language, and append new `##` sections covering three beats:
+Read the whole file, match its voice and language, and append new `##` sections covering four beats, in this order:
 
-1. **What was done** — changes, decisions, outcomes.
-2. **The discussions with the LLM** — what was proposed, what the author pushed back on or corrected, how it resolved. A wrong first diagnosis is content, not noise.
-3. **Proof that generated code works** — the generated test snippet (trimmed to the relevant assertion), one or two sentences on why passing it proves the fix (what failed before), and the real test-runner output. Include the red pre-fix run when available. For untestable changes, show the command run and its real output.
+1. **The goal, with a concrete example** — open with what this session set out to accomplish, shown concretely (the user story, the input the user writes, the command they run, the output they should get) *before* any how. A reader must know what success looks like before reading how it was reached.
+2. **What was done** — changes, decisions, outcomes.
+3. **The discussions with the LLM** — what was proposed, what the author pushed back on or corrected, how it resolved. A wrong first diagnosis is content, not noise.
+4. **Proof that generated code works** — the generated test snippet (trimmed to the relevant assertion), one or two sentences on why passing it proves the fix (what failed before), and the real test-runner output. Include the red pre-fix run when available. Prefer **oracle-based proofs**: when a reference implementation exists (real git, the real compiler, the actual API), test against its answer rather than a hardcoded expected value — and record that choice in the entry. For untestable changes, show the command run and its real output.
+
+When the session generated interesting code, also **walk through it**: quote the load-bearing snippets (trimmed) and explain why they are written that way — the tricky rule they encode, the edge they guard. The journal is where a reader should understand the code's ideas, not just its existence.
 
 Update the `*Last updated:*` date. Never rewrite or delete past sections — a reversed conclusion gets a new section saying so.
 
 ## Style rules
 
 Blog style: narrative prose meant to be read, section titles as hooks not labels, never a changelog or commit list. First person, past tense, honest, no marketing tone. Concrete: link real PRs/issues, quote measured numbers.
+
+**No meta-narration**: the journal never talks about the writing or updating of the journal itself — no "I updated this making-of", no describing the journal's own structure or the skill that produced it. Sole exception: a repository whose subject *is* the making-of practice (e.g. the skill's own repo).
 
 When the file no longer reads in one sitting and a milestone boundary exists, split into `doc/making-of/NN-slug.md` posts ([templates/making-of-post.md](templates/making-of-post.md)) and turn the root file into an index.
 

--- a/skills/documentation/making-of/prompt.md
+++ b/skills/documentation/making-of/prompt.md
@@ -21,10 +21,12 @@ Maintain a making-of journal for this repository: a first-person, blog-ish accou
 
 - Read the whole file first and match its voice, language, and formatting exactly.
 - Append one or more new `##` sections covering what happened since the last update. Do not pad: if the session produced one decision, write one short section.
-- Each update must cover three things:
-  1. **What was done** — the changes, decisions, and outcomes of the session.
-  2. **The discussions with the LLM** — what the agent proposed, what the author pushed back on or corrected, and how the disagreement resolved. A correction the author made to the agent's first answer is prime content.
-  3. **Proof that generated code works** — see "Show proof, not claims" below. If code was written this session, the update is not complete without its evidence.
+- Each update must cover four things, in this order:
+  1. **The goal, with a concrete example** — open with what the session set out to accomplish, shown concretely (the user story, the input the user writes, the command they run, the result they should get) *before* any how. The reader must know what success looks like before reading how it was reached.
+  2. **What was done** — the changes, decisions, and outcomes of the session.
+  3. **The discussions with the LLM** — what the agent proposed, what the author pushed back on or corrected, and how the disagreement resolved. A correction the author made to the agent's first answer is prime content.
+  4. **Proof that generated code works** — see "Show proof, not claims" below. If code was written this session, the update is not complete without its evidence.
+- When the session generated interesting code, also **walk through it**: quote the load-bearing snippets (trimmed) and explain why they are written that way — the tricky rule they encode, the edge case they guard. The journal is where a reader should understand the code's ideas, not just learn that it exists.
 - Update the `*Last updated:*` date. Change nothing else in the header block.
 - Never rewrite or delete past sections. If a past conclusion turned out wrong, say so in the new section — the reversal is the content.
 
@@ -36,6 +38,8 @@ When a session produced generated code (a fix, a feature), never just state that
 - **Why this test proves it** — one or two sentences connecting the assertion to the bug or requirement: what would have failed before the change, and why passing now means the behavior is correct (not just that the code runs).
 - **The actual output of running it** — the real test-runner output (trimmed), in a fenced code block. A green run that was actually executed, not a description of one. If the test was also run against the pre-fix code to show it failing, include that red output too — it is the strongest proof.
 
+Prefer **oracle-based proofs** over hardcoded expectations: when a reference implementation exists (the real git, the real compiler, the live API), the test should compare against the oracle's answer instead of a fixed expected value — a hardcoded value only asserts that the code does what the code does. Record that choice in the journal entry; the reasoning is content.
+
 If the change cannot be proven by a test (docs, config), show the equivalent evidence: the command run and its real output.
 
 ## Content rules (both modes)
@@ -46,6 +50,7 @@ If the change cannot be proven by a test (docs, config), show the equivalent evi
 - **Record the conversation.** The back-and-forth with the LLM is part of the story: what was asked, what the agent got wrong, what the author corrected. Quote the pivotal exchange when it explains a decision.
 - **Show proof, not claims.** Generated code is only "done" in the journal when the evidence is shown (see the section above).
 - **Be concrete.** Link actual PRs, issues, and files; quote measured numbers; use tables for data. When a claim was verified, say against what.
+- **No meta-narration.** The journal never talks about the writing or updating of the journal itself — no "I updated this making-of", no describing the journal's structure, its update ritual, or the skill that produced it. Sole exception: a repository whose subject *is* the making-of practice (e.g. the repo hosting this skill).
 - **Keep it readable in one sitting.** Sections short, one idea each.
 
 ## Splitting into a post series


### PR DESCRIPTION
Four improvements to the making-of skill, all learned from applying it on a real project:

1. **Goal first, with a concrete example** — every session/milestone entry now opens with what it set out to accomplish, shown concretely (the input the user writes, the command they run, the result they should get), *before* any how.
2. **Oracle-based proofs** — when a reference implementation exists (real git, real compiler, live API), the proof test should compare against the oracle's answer rather than a hardcoded expected value, and the entry records that choice.
3. **Code walkthroughs** — when a session generates interesting code, the entry quotes the load-bearing snippets and explains why they are written that way, in addition to the test proof.
4. **No meta-narration guardrail** — the journal never talks about its own writing or updating; the sole exception is a repository whose subject *is* the making-of practice (like this skill's repo).

Applied to `SKILL.md` (the update beats become four, ordered), `prompt.md`, and `README.md`. Plugin and marketplace versions bumped to 1.1.0 so installed users pick up the change; `claude plugin validate` passes and the inventory still lists all 5 skills.

🤖 Generated with [Claude Code](https://claude.com/claude-code)