### PR TITLE
feat(release-please): warn about the repository setting and tell the user

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Reusable AI-agent skills library: GitHub Actions workflows (Surge deploys, PR previews, release-please), webapp snippets, and documentation practices (making-of journals).",
-    "version": "1.3.0"
+    "version": "1.4.0"
   },
   "plugins": [
     {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ai-skills",
   "description": "Reusable AI-agent skills: GitHub Actions workflows (Surge deploys, PR previews, release-please), webapp snippets, and documentation practices (making-of journals).",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "author": {
     "name": "Sun S. D. Tan",
     "url": "https://github.com/sunix"

--- a/skills/github-actions/release-please/README.md
+++ b/skills/github-actions/release-please/README.md
@@ -21,6 +21,24 @@ Keep a continuously updated "Release PR" that accumulates [Conventional Commits]
 
 Every push to `main` causes release-please to evaluate new commits and keep the Release PR up to date.
 
+## Required repository setting
+
+**Settings → Actions → General → Workflow permissions → "Allow GitHub Actions to create
+and approve pull requests"** must be enabled. It is off by default, and set per
+repository.
+
+Without it, release-please parses your commits, computes the versions, writes the
+changelog, pushes its own `release-please--branches--main` branch — and then fails on the
+last call:
+
+```text
+release-please failed: GitHub Actions is not permitted to create or approve pull requests.
+```
+
+No Release PR appears, and because nothing else depends on this workflow, the red run is
+easy to miss. Check the workflow's status after your first merge instead of concluding
+that there was nothing to release.
+
 ## Required secrets
 
 No secrets are strictly required. The workflow uses the built-in `GITHUB_TOKEN` by default.

--- a/skills/github-actions/release-please/SKILL.md
+++ b/skills/github-actions/release-please/SKILL.md
@@ -14,6 +14,30 @@ Copy [templates/release-please.yml](templates/release-please.yml) to `.github/wo
 - Token: `${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}` — a PAT lets the published release trigger downstream `on: release` workflows (the default `GITHUB_TOKEN` cannot, due to GitHub's anti-loop safeguard); the fallback keeps it zero-setup.
 - Do not add `release-please-config.json` / `.release-please-manifest.json` unless the user explicitly asks for multi-package or custom configuration.
 
+## Tell the user about the repository setting — this one is not optional
+
+release-please cannot open its Release PR unless **Settings → Actions → General →
+Workflow permissions → "Allow GitHub Actions to create and approve pull requests"** is
+enabled. It is **off by default**, and it is a *per-repository* setting: having enabled it
+on another repository does not help.
+
+After adding the workflow, **say this to the user explicitly** — do not leave it in a file
+they may not read. Without it, the first push to `main` ends with:
+
+```text
+release-please failed: GitHub Actions is not permitted to create or approve pull requests.
+```
+
+Why this deserves its own warning: the failure is nearly invisible. release-please does
+all its work first — parses the commits, computes versions, writes the changelog, even
+creates and pushes its own `release-please--branches--main` branch — and only then dies on
+the final API call. Nothing downstream depends on that workflow yet, so the red run sits
+unnoticed. In one real repository it failed on **five consecutive pushes** before anyone
+looked.
+
+So also tell the user to **check that workflow's run status after the first merge**,
+rather than assuming that no Release PR means no releasable commits.
+
 Then update the project's agent instruction file (`AGENT.md`, `CLAUDE.md`, `.github/copilot-instructions.md` — whichever exists, else create `AGENT.md`) to enforce **Conventional Commits** (`feat:` → minor, `fix:` → patch, `feat!:`/`BREAKING CHANGE:` → major) for commits and PR titles, and one logical commit per PR.
 
 Full requirements list: [prompt.md](prompt.md). Human documentation: [README.md](README.md).

--- a/skills/github-actions/release-please/prompt.md
+++ b/skills/github-actions/release-please/prompt.md
@@ -22,6 +22,16 @@ Requirements:
 
 Do not add `release-please-config.json` or `.release-please-manifest.json` unless the user explicitly asks for multi-package or custom configuration.
 
+After adding the workflow, **tell the user in your reply** that they must enable
+**Settings → Actions → General → Workflow permissions → "Allow GitHub Actions to create
+and approve pull requests"**. It is off by default and set per repository. Without it,
+release-please does all of its work and then fails on the last step with
+`GitHub Actions is not permitted to create or approve pull requests`, having already
+created its release branch — a failure quiet enough to go unnoticed for several pushes,
+because nothing downstream depends on that workflow yet. Tell them to check the workflow's
+run status after the first merge rather than assuming that "no Release PR" means "nothing
+to release".
+
 After adding the workflow, update the project's agent instruction file (e.g. `AGENT.md`, `CLAUDE.md`, `.github/copilot-instructions.md`, or whichever agent file already exists in the repository). Add or extend a section that enforces:
 - **Conventional Commits** for all commit messages and pull request titles (format: `<type>[scope]: <description>`, e.g. `feat: add login page`, `fix(auth): correct redirect`). This is required for release-please to compute version bumps correctly.
 - **One logical commit per pull request** — squash intermediate commits before opening or updating a PR.


### PR DESCRIPTION
The skill produced a workflow that cannot work until a repository setting is flipped, and said nothing about it. That cost five silent red runs in [diderot](https://github.com/sunix/diderot) and one here before anyone thought to look at the workflow.

## What the skill now does

Tells the agent to **say it in its reply**, not to file it somewhere:

> **Settings → Actions → General → Workflow permissions → "Allow GitHub Actions to create and approve pull requests"** must be enabled. It is **off by default**, and it is a *per-repository* setting: having enabled it on another repository does not help.

And to tell the user to **check the workflow's run status after the first merge**, rather than assuming that "no Release PR" means "nothing releasable".

## Why it deserves the emphasis

The failure mode is what makes it dangerous, and the skill now explains it: release-please does *all* its work first — parses commits, computes versions, writes the changelog, even creates and pushes `release-please--branches--main` — and only then dies on the final API call:

```text
release-please failed: GitHub Actions is not permitted to create or approve pull requests.
```

Nothing downstream depends on that workflow yet, so the red run sits there unnoticed. Silence looks exactly like "no releasable commits".

Added to all three files (`SKILL.md`, `prompt.md`, `README.md`), each in its own register: an instruction to the agent, a line in the agent-facing prompt, and a "Required repository setting" section for humans. Plugin and marketplace bumped to 1.4.0; `claude plugin validate` passes and all five skills still resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)