### PR TITLE
chore: ignore skills installed by diderot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,7 @@ build/
 # Secrets
 .env
 .env.*
+
+# Skills installed by diderot. Materialised content, rebuilt by `diderot install`
+# from the digests in diderot.lock - so the lock is what belongs in git, not this.
+.claude/skills/


### PR DESCRIPTION
Trying diderot in this repository left `.claude/skills/making-of/` on disk and untracked. One line
so it stays that way.

```gitignore
# Skills installed by diderot. Materialised content, rebuilt by `diderot install`
# from the digests in diderot.lock - so the lock is what belongs in git, not this.
.claude/skills/
```

`.claude/skills/` only, not `.claude/` — settings and commands under there are legitimately
committable; installed skill content is not.

## Why it matters more here than in a normal consumer

ai-skills is where `making-of` is **authored**. Installing it from ghcr.io puts a published copy at
`.claude/skills/making-of/` right next to its source at `skills/documentation/making-of/` — two
copies of one skill in one tree, only one of which is publishable, and an agent reading the installed
one would be reading last release rather than the work in progress.

Which is also why I have **not** committed the `diderot.yaml` and `diderot.lock` that are sitting
untracked next to it, even though you said I could. A manifest here declaring
`oci://ghcr.io/sunix/skills/making-of` makes this repository a consumer of its own output. Happy to
commit them if you want the dogfooding on record anyway — say so and I will — but the circularity
seemed worth flagging before making it permanent. In diderot's own repository the same manifest is
unambiguously right, since it consumes the skill without authoring it.