### PR TITLE
feat(making-of): state the register the other rules follow from

### DIFF
--- a/skills/documentation/making-of/SKILL.md
+++ b/skills/documentation/making-of/SKILL.md
@@ -7,6 +7,8 @@ description: Create or update a first-person, blog-style "making-of" journal (MA
 
 Maintain a making-of journal for the current repository: a first-person, blog-style account of how the project is being built, written in the author's voice.
 
+**Write as the author with another developer sitting beside them.** Every entry is that conversation: here is the feature I built, here is why it needed building, here is the code I wrote and why it reads the way it does, and here is the proof it does what I set out to do. The rules below all follow from that one, so when they seem to conflict, ask what you would actually say to somebody looking at the screen with you. Showing beats describing. A snippet beats a summary of a snippet. A claim with no output under it is not finished. A section that would embarrass you if read aloud to that person is wrong, however well written.
+
 ## If `MAKING-OF.md` does not exist (bootstrap)
 
 Create it at the repository root from [templates/MAKING-OF.md](templates/MAKING-OF.md): a three-part header (title "Building X: ..., one prompt at a time"; italic intro stating what the document is, its journal style, audience, and update policy; a `*Last updated: YYYY-MM-DD.*` line), then a "Why this exists" section. Draft initial entries from git history and the current conversation; ask the author about anything you cannot reconstruct instead of inventing it. Write in the language the author uses with you.

--- a/skills/documentation/making-of/prompt.md
+++ b/skills/documentation/making-of/prompt.md
@@ -6,6 +6,8 @@ Use this prompt to instruct an AI agent to create or update a first-person makin
 
 Maintain a making-of journal for this repository: a first-person, blog-ish account of how the project is being built, written in the author's voice, for new contributors and anyone curious how it came together.
 
+**Write as the author with another developer sitting beside them.** Every entry is that conversation: here is the feature I built, here is why it needed building, here is the code I wrote and why it reads the way it does, and here is the proof it does what I set out to do. The rules below all follow from that one, so when they seem to conflict, ask what you would actually say to somebody looking at the screen with you. Showing beats describing. A snippet beats a summary of a snippet. A claim with no output under it is not finished. A section that would embarrass you if read aloud to that person is wrong, however well written.
+
 ## If the file does not exist yet (bootstrap)
 
 - Create `MAKING-OF.md` at the repository root. Copy the skeleton from `skills/documentation/making-of/templates/MAKING-OF.md`.


### PR DESCRIPTION
Came out of writing [diderot#34](https://github.com/sunix/diderot/pull/34)'s chapter, where the same
correction had to be made four times in review: I kept describing code instead of showing it, and
alluding to output instead of quoting it.

The skill already forbids all of that. It says to walk through code shoulder-to-shoulder, to name the
file worth opening, to quote the load-bearing snippets, to put real output under a claim. But every
one of those is phrased as a **style rule about fenced blocks** — so they have to be remembered
individually, and an entry can satisfy each of them and still read like a report to a committee.

What was missing is who is speaking. In the author's own words: *writing a new feature of diderot and
explaining it to another developer sitting next to me — the how, the why, showing and explaining the
code I produced, then proving it works and matches the goal.*

Stated first, the existing rules stop being a checklist and become consequences:

```markdown
**Write as the author with another developer sitting beside them.** Every entry is that conversation:
here is the feature I built, here is why it needed building, here is the code I wrote and why it reads
the way it does, and here is the proof it does what I set out to do. The rules below all follow from
that one, so when they seem to conflict, ask what you would actually say to somebody looking at the
screen with you. Showing beats describing. A snippet beats a summary of a snippet. A claim with no
output under it is not finished. A section that would embarrass you if read aloud to that person is
wrong, however well written.
```

Added straight after the opening line of `SKILL.md`, and mirrored in `prompt.md` so the two do not
drift. Unwrapped to match how both files are written — neither wraps its prose.

## Why a `feat` and not a `docs`

It changes what an agent following the skill produces, not how the skill is explained to a human, so
it earns a minor bump. release-please will move `making-of` to 1.2.0 and publish it; `version.txt` is
left alone here since that is release-please's to write.

## What I did not add

A worked example of the register. `examples/example-usage.md` already carries the proof pattern, and
the four corrections behind this PR were all failures to *apply* a rule that was present, not
failures to understand one — so another example seemed likely to add length without adding pressure.
Happy to be argued out of that.