### PR TITLE
docs: show how to install each skill with diderot

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,17 @@ gh skill install sunix/ai-skills making-of
 npx skills add sunix/ai-skills
 ```
 
+Or with [diderot](https://github.com/sunix/diderot), which resolves a semver range against the tags a
+registry publishes and verifies the installed bytes against a content digest:
+
+```bash
+diderot add oci://ghcr.io/sunix/skills/making-of --version "^1.0.0"
+diderot install
+```
+
+Every skill's own README carries both forms — the registry source above and the git source pointing
+back here — plus the `diderot.yaml` entry to copy if you would rather declare it by hand.
+
 ## Purpose
 
 This repository serves as a shared reference for AI agents and human developers. Instead of generating the same patterns from scratch each time, agents can discover, copy, and adapt skills from this library.

--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ All skills then load automatically (invoke them as `/ai-skills:making-of`, `/ai-
 Because every skill follows the open Agent Skills format, generic skill installers work too:
 
 ```bash
-# GitHub CLI (v2.90+)
-gh skill install sunix/ai-skills making-of
+# GitHub CLI (v2.90+) — name the agent: non-interactively it defaults to github-copilot
+gh skill install sunix/ai-skills making-of --agent claude-code
 
 # npx skills (installs into .claude/skills/ or .agents/skills/)
 npx skills add sunix/ai-skills
@@ -37,7 +37,7 @@ Or with [diderot](https://github.com/sunix/diderot), which resolves a semver ran
 registry publishes and verifies the installed bytes against a content digest:
 
 ```bash
-diderot add oci://ghcr.io/sunix/skills/making-of --version "^1.0.0"
+diderot add oci://ghcr.io/sunix/skills/making-of --version latest
 diderot install
 ```
 

--- a/skills/documentation/making-of/README.md
+++ b/skills/documentation/making-of/README.md
@@ -7,7 +7,7 @@ Maintain a first-person "making-of" journal in a repository — a blog-ish accou
 [diderot](https://github.com/sunix/diderot) is a package manager for agent skills: it resolves a version constraint, pins what it resolved to by content digest in `diderot.lock`, and installs the same bytes anywhere. From the registry:
 
 ```bash
-diderot add oci://ghcr.io/sunix/skills/making-of --version "^1.0.0"
+diderot add oci://ghcr.io/sunix/skills/making-of --version latest
 diderot install
 ```
 
@@ -24,7 +24,7 @@ diderot install
 skills:
   - name: making-of
     source: oci://ghcr.io/sunix/skills/making-of
-    version: "^1.0.0"      # newest 1.x — or an exact tag, or `latest`
+    version: latest        # or an exact tag, or a range like "^1.0.0"
 targets: [claude]          # or [agents], for .agents/skills
 ```
 

--- a/skills/documentation/making-of/README.md
+++ b/skills/documentation/making-of/README.md
@@ -2,6 +2,32 @@
 
 Maintain a first-person "making-of" journal in a repository — a blog-ish account of how the project is being built, updated at the end of each AI-assisted work session.
 
+## Install it with diderot
+
+[diderot](https://github.com/sunix/diderot) is a package manager for agent skills: it resolves a version constraint, pins what it resolved to by content digest in `diderot.lock`, and installs the same bytes anywhere. From the registry:
+
+```bash
+diderot add oci://ghcr.io/sunix/skills/making-of --version "^1.0.0"
+diderot install
+```
+
+Or from this repository, to follow git rather than releases:
+
+```bash
+diderot add git+https://github.com/sunix/ai-skills#skills/documentation/making-of --version main
+diderot install
+```
+
+`diderot add` needs a build newer than v0.2.0 ([diderot#34](https://github.com/sunix/diderot/pull/34)). With v0.2.0, declare it in `diderot.yaml` yourself and run `diderot update && diderot install`:
+
+```yaml
+skills:
+  - name: making-of
+    source: oci://ghcr.io/sunix/skills/making-of
+    version: "^1.0.0"      # newest 1.x — or an exact tag, or `latest`
+targets: [claude]          # or [agents], for .agents/skills
+```
+
 ## Purpose
 
 Formal docs explain **what** the project is. A making-of records **how it came together**: the reasoning, the measurements, the false starts, and the reversals — especially the reversals. It is written for new contributors, for future-you, and for anyone curious about building software with AI agents, and it may later turn into an actual blog post.

--- a/skills/github-actions/pr-preview-surge/README.md
+++ b/skills/github-actions/pr-preview-surge/README.md
@@ -2,6 +2,32 @@
 
 Deploy a static site PR preview to [Surge](https://surge.sh) when a `/preview` comment is posted on a pull request.
 
+## Install it with diderot
+
+[diderot](https://github.com/sunix/diderot) is a package manager for agent skills: it resolves a version constraint, pins what it resolved to by content digest in `diderot.lock`, and installs the same bytes anywhere. From the registry:
+
+```bash
+diderot add oci://ghcr.io/sunix/skills/pr-preview-surge --version "^1.0.0"
+diderot install
+```
+
+Or from this repository, to follow git rather than releases:
+
+```bash
+diderot add git+https://github.com/sunix/ai-skills#skills/github-actions/pr-preview-surge --version main
+diderot install
+```
+
+`diderot add` needs a build newer than v0.2.0 ([diderot#34](https://github.com/sunix/diderot/pull/34)). With v0.2.0, declare it in `diderot.yaml` yourself and run `diderot update && diderot install`:
+
+```yaml
+skills:
+  - name: pr-preview-surge
+    source: oci://ghcr.io/sunix/skills/pr-preview-surge
+    version: "^1.0.0"      # newest 1.x — or an exact tag, or `latest`
+targets: [claude]          # or [agents], for .agents/skills
+```
+
 ## Purpose
 
 Give reviewers a live preview URL for every pull request with a single comment. The workflow builds the site from the PR merge ref and publishes it to a deterministic Surge URL.

--- a/skills/github-actions/pr-preview-surge/README.md
+++ b/skills/github-actions/pr-preview-surge/README.md
@@ -7,7 +7,7 @@ Deploy a static site PR preview to [Surge](https://surge.sh) when a `/preview` c
 [diderot](https://github.com/sunix/diderot) is a package manager for agent skills: it resolves a version constraint, pins what it resolved to by content digest in `diderot.lock`, and installs the same bytes anywhere. From the registry:
 
 ```bash
-diderot add oci://ghcr.io/sunix/skills/pr-preview-surge --version "^1.0.0"
+diderot add oci://ghcr.io/sunix/skills/pr-preview-surge --version latest
 diderot install
 ```
 
@@ -24,7 +24,7 @@ diderot install
 skills:
   - name: pr-preview-surge
     source: oci://ghcr.io/sunix/skills/pr-preview-surge
-    version: "^1.0.0"      # newest 1.x — or an exact tag, or `latest`
+    version: latest        # or an exact tag, or a range like "^1.0.0"
 targets: [claude]          # or [agents], for .agents/skills
 ```
 

--- a/skills/github-actions/push-to-surge/README.md
+++ b/skills/github-actions/push-to-surge/README.md
@@ -2,6 +2,32 @@
 
 Deploy a static site to [Surge](https://surge.sh) automatically when code is pushed to the `main` branch.
 
+## Install it with diderot
+
+[diderot](https://github.com/sunix/diderot) is a package manager for agent skills: it resolves a version constraint, pins what it resolved to by content digest in `diderot.lock`, and installs the same bytes anywhere. From the registry:
+
+```bash
+diderot add oci://ghcr.io/sunix/skills/push-to-surge --version "^1.0.0"
+diderot install
+```
+
+Or from this repository, to follow git rather than releases:
+
+```bash
+diderot add git+https://github.com/sunix/ai-skills#skills/github-actions/push-to-surge --version main
+diderot install
+```
+
+`diderot add` needs a build newer than v0.2.0 ([diderot#34](https://github.com/sunix/diderot/pull/34)). With v0.2.0, declare it in `diderot.yaml` yourself and run `diderot update && diderot install`:
+
+```yaml
+skills:
+  - name: push-to-surge
+    source: oci://ghcr.io/sunix/skills/push-to-surge
+    version: "^1.0.0"      # newest 1.x — or an exact tag, or `latest`
+targets: [claude]          # or [agents], for .agents/skills
+```
+
 ## Purpose
 
 Publish the latest version of your static site to Surge on every push to `main`, giving you a continuously updated live URL without any manual steps.

--- a/skills/github-actions/push-to-surge/README.md
+++ b/skills/github-actions/push-to-surge/README.md
@@ -7,7 +7,7 @@ Deploy a static site to [Surge](https://surge.sh) automatically when code is pus
 [diderot](https://github.com/sunix/diderot) is a package manager for agent skills: it resolves a version constraint, pins what it resolved to by content digest in `diderot.lock`, and installs the same bytes anywhere. From the registry:
 
 ```bash
-diderot add oci://ghcr.io/sunix/skills/push-to-surge --version "^1.0.0"
+diderot add oci://ghcr.io/sunix/skills/push-to-surge --version latest
 diderot install
 ```
 
@@ -24,7 +24,7 @@ diderot install
 skills:
   - name: push-to-surge
     source: oci://ghcr.io/sunix/skills/push-to-surge
-    version: "^1.0.0"      # newest 1.x — or an exact tag, or `latest`
+    version: latest        # or an exact tag, or a range like "^1.0.0"
 targets: [claude]          # or [agents], for .agents/skills
 ```
 

--- a/skills/github-actions/release-please/README.md
+++ b/skills/github-actions/release-please/README.md
@@ -2,6 +2,32 @@
 
 Automate versioning and GitHub Releases using [release-please](https://github.com/googleapis/release-please).
 
+## Install it with diderot
+
+[diderot](https://github.com/sunix/diderot) is a package manager for agent skills: it resolves a version constraint, pins what it resolved to by content digest in `diderot.lock`, and installs the same bytes anywhere. From the registry:
+
+```bash
+diderot add oci://ghcr.io/sunix/skills/release-please --version "^1.0.0"
+diderot install
+```
+
+Or from this repository, to follow git rather than releases:
+
+```bash
+diderot add git+https://github.com/sunix/ai-skills#skills/github-actions/release-please --version main
+diderot install
+```
+
+`diderot add` needs a build newer than v0.2.0 ([diderot#34](https://github.com/sunix/diderot/pull/34)). With v0.2.0, declare it in `diderot.yaml` yourself and run `diderot update && diderot install`:
+
+```yaml
+skills:
+  - name: release-please
+    source: oci://ghcr.io/sunix/skills/release-please
+    version: "^1.0.0"      # newest 1.x — or an exact tag, or `latest`
+targets: [claude]          # or [agents], for .agents/skills
+```
+
 ## Purpose
 
 Keep a continuously updated "Release PR" that accumulates [Conventional Commits](https://www.conventionalcommits.org/) changes. Merging that PR automatically bumps the version, publishes a GitHub Release, creates a tag, and updates `CHANGELOG.md` — with no manual steps.

--- a/skills/github-actions/release-please/README.md
+++ b/skills/github-actions/release-please/README.md
@@ -7,7 +7,7 @@ Automate versioning and GitHub Releases using [release-please](https://github.co
 [diderot](https://github.com/sunix/diderot) is a package manager for agent skills: it resolves a version constraint, pins what it resolved to by content digest in `diderot.lock`, and installs the same bytes anywhere. From the registry:
 
 ```bash
-diderot add oci://ghcr.io/sunix/skills/release-please --version "^1.0.0"
+diderot add oci://ghcr.io/sunix/skills/release-please --version latest
 diderot install
 ```
 
@@ -24,7 +24,7 @@ diderot install
 skills:
   - name: release-please
     source: oci://ghcr.io/sunix/skills/release-please
-    version: "^1.0.0"      # newest 1.x — or an exact tag, or `latest`
+    version: latest        # or an exact tag, or a range like "^1.0.0"
 targets: [claude]          # or [agents], for .agents/skills
 ```
 

--- a/skills/webapp/github-star-button/README.md
+++ b/skills/webapp/github-star-button/README.md
@@ -7,7 +7,7 @@ Add a GitHub star button to a webapp that displays the live star count of a repo
 [diderot](https://github.com/sunix/diderot) is a package manager for agent skills: it resolves a version constraint, pins what it resolved to by content digest in `diderot.lock`, and installs the same bytes anywhere. From the registry:
 
 ```bash
-diderot add oci://ghcr.io/sunix/skills/github-star-button --version "^1.0.0"
+diderot add oci://ghcr.io/sunix/skills/github-star-button --version latest
 diderot install
 ```
 
@@ -24,7 +24,7 @@ diderot install
 skills:
   - name: github-star-button
     source: oci://ghcr.io/sunix/skills/github-star-button
-    version: "^1.0.0"      # newest 1.x — or an exact tag, or `latest`
+    version: latest        # or an exact tag, or a range like "^1.0.0"
 targets: [claude]          # or [agents], for .agents/skills
 ```
 

--- a/skills/webapp/github-star-button/README.md
+++ b/skills/webapp/github-star-button/README.md
@@ -2,6 +2,32 @@
 
 Add a GitHub star button to a webapp that displays the live star count of a repository and links visitors directly to the GitHub page to star it.
 
+## Install it with diderot
+
+[diderot](https://github.com/sunix/diderot) is a package manager for agent skills: it resolves a version constraint, pins what it resolved to by content digest in `diderot.lock`, and installs the same bytes anywhere. From the registry:
+
+```bash
+diderot add oci://ghcr.io/sunix/skills/github-star-button --version "^1.0.0"
+diderot install
+```
+
+Or from this repository, to follow git rather than releases:
+
+```bash
+diderot add git+https://github.com/sunix/ai-skills#skills/webapp/github-star-button --version main
+diderot install
+```
+
+`diderot add` needs a build newer than v0.2.0 ([diderot#34](https://github.com/sunix/diderot/pull/34)). With v0.2.0, declare it in `diderot.yaml` yourself and run `diderot update && diderot install`:
+
+```yaml
+skills:
+  - name: github-star-button
+    source: oci://ghcr.io/sunix/skills/github-star-button
+    version: "^1.0.0"      # newest 1.x — or an exact tag, or `latest`
+targets: [claude]          # or [agents], for .agents/skills
+```
+
 ## Purpose
 
 Encourage visitors to star your repository by surfacing the current star count alongside a direct link to the GitHub repo page, updated dynamically on every page load.


### PR DESCRIPTION
Depends on [diderot#34](https://github.com/sunix/diderot/pull/34), which adds `diderot add` — every
block here says so and gives the by-hand path that works with the released v0.2.0.

## What each skill README gains

Right under its description, so it is the first thing after "what is this":

````markdown
## Install it with diderot

[diderot](https://github.com/sunix/diderot) is a package manager for agent skills: it resolves a
version constraint, pins what it resolved to by content digest in `diderot.lock`, and installs the
same bytes anywhere. From the registry:

```bash
diderot add oci://ghcr.io/sunix/skills/making-of --version "^1.0.0"
diderot install
```

Or from this repository, to follow git rather than releases:

```bash
diderot add git+https://github.com/sunix/ai-skills#skills/documentation/making-of --version main
diderot install
```

`diderot add` needs a build newer than v0.2.0 (diderot#34). With v0.2.0, declare it in
`diderot.yaml` yourself and run `diderot update && diderot install`:

```yaml
skills:
  - name: making-of
    source: oci://ghcr.io/sunix/skills/making-of
    version: "^1.0.0"      # newest 1.x — or an exact tag, or `latest`
targets: [claude]          # or [agents], for .agents/skills
```
````

All five skills, with their own name, registry repository and git path substituted.

## Verified rather than assumed

The commands were copied back out of the rendered READMEs and run in a scratch directory, because a
README that tells somebody to run something ought to have had it run at least once:

```console
$ diderot add oci://ghcr.io/sunix/skills/github-star-button --version "^1.0.0"
added github-star-button   oci://ghcr.io/sunix/skills/github-star-button (^1.0.0)
locked github-star-button  ghcr.io/…/github-star-button:1.1.0@sha256:4bb60d3b3f05 (tree:0857c53016d4…)

$ diderot add git+https://github.com/sunix/ai-skills#skills/documentation/making-of --version main
added making-of            git+https://github.com/sunix/ai-skills#skills/documentation/making-of (main)
locked making-of           https://github.com/sunix/ai-skills@58abd575e5a3 (tree:05fd2ca9ca18…)

$ diderot install
installed github-star-button -> .claude/skills/github-star-button (tree:0857c53016d4… verified)
installed making-of          -> .claude/skills/making-of (tree:05fd2ca9ca18… verified)
```

So both source forms resolve, and both digests verify after extraction.

## Also: the root README did not mention diderot

Its install section offered the plugin marketplace, `gh skill install` and `npx skills add`, and
nothing else — zero occurrences of the word. Added, described by what it actually does differently
rather than by being ranked against the others: resolving a semver range against the tags a registry
publishes, and verifying installed bytes against a content digest.

## One thing worth deciding

This is a `docs:` commit, so release-please bumps nothing — which means the published artifacts keep
their current READMEs until each skill's next release for some other reason. That seemed better than
manufacturing five `fix(...)` commits to force patch bumps, but it does mean
`ghcr.io/sunix/skills/making-of:1.1.0` and this repository disagree about that file for a while. Say
the word if you would rather they were bumped.